### PR TITLE
Fix Code that Sets the Radius on Reports

### DIFF
--- a/age_and_education/age_and_education.js
+++ b/age_and_education/age_and_education.js
@@ -76,13 +76,12 @@ var chart2 = c3.generate({
 
 $("title").html(`Age and Education Report for ${address}`);
 $(".address").html(address);
+var radius = data["reportSpecification"]["geoJSON"]["geometry"]["radius"];
 
 if(data.type == "polygon"){
   $("#point").hide();
 }else{
-  var radius = data["reportSpecification"]["geoJSON"]["geometry"]["radius"];
-
-  $("#radius").html(data["reportSpecification"]["geoJSON"]["geometry"]["radius"]);
+  $("#radius").html(Math.floor(radius/1600));
   $("#polygon").hide()
 }
 

--- a/general_demographic/general_demographic.js
+++ b/general_demographic/general_demographic.js
@@ -166,13 +166,11 @@ var chart5 = c3.generate({
 //
 $("title").html(`General Demographic Report for ${data["address"]}`);
 $(".address").html(address);
-
+var radius = data["reportSpecification"]["geoJSON"]["geometry"]["radius"];
 
 if(data.type == "polygon"){
   $("#point").hide();
 }else{
-  var radius = data["reportSpecification"]["geoJSON"]["geometry"]["radius"];
-    
   $("#radius").html(Math.floor(radius/1600));
   $("#polygon").hide()
 }

--- a/general_demographic/general_demographic.js
+++ b/general_demographic/general_demographic.js
@@ -175,7 +175,7 @@ if(data.type == "polygon"){
 
   radius = Math.floor(radius/1600)
     
-  $("#radius").html(data["reportSpecification"]["geoJSON"]["geometry"]["radius"]);
+  $("#radius").html(radius);
   $("#polygon").hide()
 }
 

--- a/general_demographic/general_demographic.js
+++ b/general_demographic/general_demographic.js
@@ -173,6 +173,8 @@ if(data.type == "polygon"){
 }else{
   var radius = data["reportSpecification"]["geoJSON"]["geometry"]["radius"];
 
+  radius = Math.floor(radius/1600)
+    
   $("#radius").html(data["reportSpecification"]["geoJSON"]["geometry"]["radius"]);
   $("#polygon").hide()
 }

--- a/general_demographic/general_demographic.js
+++ b/general_demographic/general_demographic.js
@@ -172,10 +172,8 @@ if(data.type == "polygon"){
   $("#point").hide();
 }else{
   var radius = data["reportSpecification"]["geoJSON"]["geometry"]["radius"];
-
-  radius = Math.floor(radius/1600)
     
-  $("#radius").html(radius);
+  $("#radius").html(Math.floor(radius/1600));
   $("#polygon").hide()
 }
 

--- a/longitudinal_house_value/longitudinal_house_value.js
+++ b/longitudinal_house_value/longitudinal_house_value.js
@@ -13,15 +13,13 @@ window.printReport = function(){
 var type = data["reportSpecification"]["geoJSON"]["geometry"]["type"];
 var address = data["reportSpecification"]["geoJSON"]["properties"]["address"];
 var coordinates = data["reportSpecification"]["geoJSON"]["geometry"]["coordinates"];
-//
+var radius = data["reportSpecification"]["geoJSON"]["geometry"]["radius"];
 
 $(".address").html(address);
 if(data.type == "polygon"){
   $("#point").hide();
 }else{
-  var radius = data["reportSpecification"]["geoJSON"]["geometry"]["radius"];
-
-  $("#radius").html(data["reportSpecification"]["geoJSON"]["geometry"]["radius"]);
+  $("#radius").html(Math.floor(radius/1600));
   $("#polygon").hide()
 }
 

--- a/longitudinal_median_income/longitudinal_median_income.js
+++ b/longitudinal_median_income/longitudinal_median_income.js
@@ -13,14 +13,14 @@ window.printReport = function(){
 var type = data["reportSpecification"]["geoJSON"]["geometry"]["type"];
 var address = data["reportSpecification"]["geoJSON"]["properties"]["address"];
 var coordinates = data["reportSpecification"]["geoJSON"]["geometry"]["coordinates"];
-//
+var radius = data["reportSpecification"]["geoJSON"]["geometry"]["radius"];
 
 $("title").html(`Longitudinal Median Income Report for ${data["address"]}`);
 $(".address").html(address);
 if(data.type == "polygon"){
   $("#point").hide();
 }else{
-  $("#radius").html(data["radius"]);
+  $("#radius").html(Math.floor(radius/1600));
   $("#polygon").hide()
 }
 

--- a/longitudinal_population/longitudinal_population.js
+++ b/longitudinal_population/longitudinal_population.js
@@ -13,14 +13,16 @@ window.printReport = function(){
 var type = data["reportSpecification"]["geoJSON"]["geometry"]["type"];
 var address = data["reportSpecification"]["geoJSON"]["properties"]["address"];
 var coordinates = data["reportSpecification"]["geoJSON"]["geometry"]["coordinates"];
-//
+var radius = data["reportSpecification"]["geoJSON"]["geometry"]["radius"];
+
+
 
 $("title").html(`Longitudinal Population Report for ${data["address"]}`);
 $(".address").html(address);
 if(data.type == "polygon"){
   $("#point").hide();
 }else{
-  $("#radius").html(data["radius"]);
+  $("#radius").html(Math.floor(radius/1600));
   $("#polygon").hide()
 }
 


### PR DESCRIPTION
Previous code was pulling from a variety of sources and doing strange maths.  This commit standardizes how the radius is being set for a report.  The radius is accessed via the ReportSpecification and then adjusted accordingly.